### PR TITLE
Ensure dist contents are published with the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+# Keep the compiled output in the published package even though it is git-ignored.
+!dist/
+
+# Exclude development-only sources and assets from the npm tarball.
+src/
+docs/
+tests/
+tools/
+debug-test/
+*.tsbuildinfo
+
+# Logs and coverage artifacts are not needed in published packages.
+*.log
+coverage/
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "TypeScript API Gateway VTL engine with exact APIGW behavior using Chevrotain",
   "main": "dist/index.js",
   "type": "module",
+  "files": [
+    "dist/**"
+  ],
   "scripts": {
     "build": "tsc && tsc -p tools/tsconfig.json",
     "build:tools": "tsc -p tools/tsconfig.json",


### PR DESCRIPTION
## Summary
- add an explicit npmignore file that keeps the compiled dist output while excluding development artifacts
- whitelist the dist folder in package.json so only the built output ships in the package

## Testing
- npm run build
- npm pack

------
https://chatgpt.com/codex/tasks/task_e_68cb15a2a87c8327955f96fa9b83d448