### PR TITLE
chore(package): rename npm package to velocits

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A TypeScript implementation of the Apache Velocity Template Language (VTL) with 
 ## Installation
 
 ```bash
-npm install @fearlessfara/velocits
+npm install velocits
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ npm install @fearlessfara/velocits
 ### Node.js / ESM
 
 ```typescript
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 const engine = new VelocityEngine();
 const output = engine.render('Hello, $name!', { name: 'World' });
@@ -34,7 +34,7 @@ console.log(output); // "Hello, World!"
 ### Browser (UMD)
 
 ```html
-<script src="https://unpkg.com/@fearlessfara/velocits"></script>
+<script src="https://unpkg.com/velocits"></script>
 <script>
   const engine = new VelociTS.VelocityEngine();
   const output = engine.render('Hello, $name!', { name: 'World' });
@@ -45,7 +45,7 @@ console.log(output); // "Hello, World!"
 ### String Templates
 
 ```typescript
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 const engine = new VelocityEngine();
 const template = `
@@ -66,7 +66,7 @@ console.log(output);
 ### File-Based Templates (Node.js only)
 
 ```typescript
-import { VelocityEngine, RuntimeConstants } from '@fearlessfara/velocits';
+import { VelocityEngine, RuntimeConstants } from 'velocits';
 
 // Configure engine with file resource loader
 const engine = new VelocityEngine({
@@ -89,7 +89,7 @@ const output2 = template.merge({ name: 'User' });
 ### Using RuntimeConstants
 
 ```typescript
-import { VelocityEngine, RuntimeConstants } from '@fearlessfara/velocits';
+import { VelocityEngine, RuntimeConstants } from 'velocits';
 
 const engine = new VelocityEngine();
 
@@ -116,7 +116,7 @@ if (engine.resourceExists('template.vtl')) {
 ### Stream Support (Writer/Reader Equivalents)
 
 ```typescript
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 const engine = new VelocityEngine();
 
@@ -155,7 +155,7 @@ Similar to Java Velocity's `context.put()` functionality, you can register utili
 #### Static Utility Classes
 
 ```typescript
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 // Define a utility class with static methods
 class MathUtil {
@@ -420,7 +420,7 @@ class Template {
 All Apache Velocity runtime constants are available:
 
 ```typescript
-import { RuntimeConstants } from '@fearlessfara/velocits';
+import { RuntimeConstants } from 'velocits';
 
 RuntimeConstants.FILE_RESOURCE_LOADER_PATH
 RuntimeConstants.FILE_RESOURCE_LOADER_CACHE

--- a/examples/01-basic-usage.ts
+++ b/examples/01-basic-usage.ts
@@ -5,7 +5,7 @@
  * Run with: npm run example:basic
  */
 
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 console.log('=== Basic VTL Usage Examples ===\n');
 

--- a/examples/02-utility-registration.ts
+++ b/examples/02-utility-registration.ts
@@ -6,7 +6,7 @@
  * Run with: npm run example:utils
  */
 
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 // Define utility classes
 class MathUtil {

--- a/examples/03-email-template.ts
+++ b/examples/03-email-template.ts
@@ -6,7 +6,7 @@
  * Run with: npm run example:email
  */
 
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 console.log('=== Email Template Examples ===\n');
 

--- a/examples/04-report-generator.ts
+++ b/examples/04-report-generator.ts
@@ -6,7 +6,7 @@
  * Run with: npm run example:report
  */
 
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 console.log('=== Report Generation Examples ===\n');
 

--- a/examples/05-config-generator.ts
+++ b/examples/05-config-generator.ts
@@ -6,7 +6,7 @@
  * Run with: npm run example:config
  */
 
-import { VelocityEngine } from '@fearlessfara/velocits';
+import { VelocityEngine } from 'velocits';
 
 console.log('=== Configuration File Generation Examples ===\n');
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ npm run example:config     # Configuration file generation
 These examples follow modern TypeScript best practices:
 
 1. **Direct TypeScript Execution**: Examples run directly using [`tsx`](https://github.com/privatenumber/tsx) - no compilation step needed during development
-2. **Package Imports**: Examples import from the package name (`@fearlessfara/velocits`) rather than relative paths, showing users how they would actually use the library
+2. **Package Imports**: Examples import from the package name (`velocits`) rather than relative paths, showing users how they would actually use the library
 3. **Type Safety**: Full TypeScript type checking with strict mode enabled
 4. **ESM Modules**: Modern ES module syntax throughout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fearlessfara/velocits",
+  "name": "velocits",
   "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fearlessfara/velocits",
+      "name": "velocits",
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fearlessfara/velocits",
+  "name": "velocits",
   "version": "1.2.1",
   "description": "TypeScript Apache Velocity engine with 1:1 Java compatibility",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,18 @@
   "files": [
     "dist/**",
     "dist-browser/**",
+    "!dist/**/*.map",
+    "!dist-browser/**/*.map",
+    "!dist/tests/**",
+    "!dist/tools/**",
+    "!dist/src/**",
+    "!dist/examples/**",
+    "!dist-browser/examples/**",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "npm run build:node && npm run build:browser && npm run build:umd",
+    "build": "npm run clean && npm run build:node && npm run build:browser && npm run build:umd",
     "build:node": "tsc && tsc -p tools/tsconfig.json && tsc -p tests/tsconfig.json",
     "build:browser": "tsc -p tsconfig.browser.json",
     "build:umd": "rollup -c",
@@ -40,7 +47,8 @@
     "example:report": "npm run build && tsx examples/04-report-generator.ts",
     "example:config": "npm run build && tsx examples/05-config-generator.ts",
     "dev": "tsc --watch",
-    "clean": "rm -rf dist dist-browser"
+    "clean": "rm -rf dist dist-browser",
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",


### PR DESCRIPTION
## Summary
- rename the npm package from `@fearlessfara/velocits` to `velocits`
- update docs and example imports to use the new unscoped package name
- refresh the lockfile metadata for the new package name

## Validation
- run `npm install --package-lock-only`
- run `npm pack --dry-run`